### PR TITLE
BOT-657 Add Ability to Track audio player state, send device capabilities and send audioPlayer intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,9 @@ _default: false_
 
 This will generate a new userId to send within each different conv.txt file. By default the userId is `botium-core-test-user` and when
 generated the user will be `botium-core-test-user-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` with a randomly generated UUID.
+
+### ALEXA_SMAPI_KEEP_AUDIO_PLAYER_STATE
+_default: false_
+
+If your skill contains audio player responses this will track the changes to the audio player such as the `token` and the `playerActivity`
+and allow you to use intents such as `AudioPlayer.PlaybackNearlyFinished` and other `AudioPlayer` intents and get the state back on the response.

--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ The AWS Endpoint the Skill is linked to (only required for Skill Invocation API)
 When using the Invocation API, tell Botium to use a special intent and a special slot to hand over the input text (intent resolution is done by Skill itself)
 
 ### ALEXA_SMAPI_AUDIO_CAPABILITY and ALEXA_SMAPI_DISPLAY_CAPABILITY
-_default: false
+_default: false_
 
 These will add Audio and Display capabilities when set to true to the invocation request sent to the Skill Management API.
 
 ### ALEXA_SMAPI_REFRESH_USER_ID
-_default: false
+_default: false_
 
 This will generate a new userId to send within each different conv.txt file. By default the userId is `botium-core-test-user` and when
 generated the user will be `botium-core-test-user-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` with a randomly generated UUID.

--- a/README.md
+++ b/README.md
@@ -133,3 +133,14 @@ The AWS Endpoint the Skill is linked to (only required for Skill Invocation API)
 ### ALEXA_SMAPI_INVOCATION_TEXT_INTENT and ALEXA_SMAPI_INVOCATION_TEXT_SLOT
 
 When using the Invocation API, tell Botium to use a special intent and a special slot to hand over the input text (intent resolution is done by Skill itself)
+
+### ALEXA_SMAPI_AUDIO_CAPABILITY and ALEXA_SMAPI_DISPLAY_CAPABILITY
+_default: false
+
+These will add Audio and Display capabilities when set to true to the invocation request sent to the Skill Management API.
+
+### ALEXA_SMAPI_REFRESH_USER_ID
+_default: false
+
+This will generate a new userId to send within each different conv.txt file. By default the userId is `botium-core-test-user` and when
+generated the user will be `botium-core-test-user-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` with a randomly generated UUID.

--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ class BotiumConnectorAlexaSmapi {
 
     this.refreshUserId = this.caps['ALEXA_SMAPI_REFRESH_USER_ID'] === true
 
+    this.keepAudioPlayerState = this.caps['ALEXA_SMAPI_KEEP_AUDIO_PLAYER_STATE'] === true
+
     if (this.caps['ALEXA_SMAPI_REFRESHTOKEN'] || this.caps['ALEXA_SMAPI_ACCESSTOKEN']) {
       this.profile = askConstants.PLACEHOLDER.ENVIRONMENT_VAR.PROFILE_NAME
 
@@ -189,7 +191,7 @@ class BotiumConnectorAlexaSmapi {
               }
             }
 
-            let messageText = 'no text response'
+            let messageText = 'no text response from skill'
             if (responseBody.response.outputSpeech) {
               messageText = responseBody.response.outputSpeech.text || responseBody.response.outputSpeech.ssml
             }
@@ -202,7 +204,10 @@ class BotiumConnectorAlexaSmapi {
                   const audioPlayerObject = directive
                   const audioPlayerType = directive.type.split('.')[1].toUpperCase()
 
-                  this._handleAudioPlayerEvent(audioPlayerType, audioPlayerObject)
+                  if (this.keepAudioPlayerState) {
+                    this._handleAudioPlayerEvent(audioPlayerType, audioPlayerObject)
+                  }
+
                   media = ((audioPlayerObject && audioPlayerObject.audioItem) ? [{
                     mediaUri: audioPlayerObject.audioItem.stream.url
                   }] : undefined)
@@ -221,6 +226,7 @@ class BotiumConnectorAlexaSmapi {
   }
 
   _handleAudioPlayerEvent (event, audioPlayer) {
+    debug(`handling audio player state for event ${event}. ${JSON.stringify(audioPlayer)}`)
     switch (event) {
       case 'PLAY':
         this.invocationRequest.context.AudioPlayer.playerActivity = 'PLAYING'
@@ -245,6 +251,7 @@ class BotiumConnectorAlexaSmapi {
   }
 
   _addSupportedInterfaces () {
+    debug(`adding capabilities, Display: ${this.displayCapability}, Audio: ${this.audioCapability}`)
     if (this.displayCapability || this.audioCapability) {
       const supportedInterfaces = {
         AudioPlayer: (this.audioCapability ? {} : undefined),

--- a/index.js
+++ b/index.js
@@ -207,6 +207,7 @@ class BotiumConnectorAlexaSmapi {
           this._handleAudioPlayerRequest(currentInvocationRequest)
         } else {
           delete currentInvocationRequest.request.token
+          delete currentInvocationRequest.request.error
         }
 
         debug(`currentInvocationRequest: ${JSON.stringify(currentInvocationRequest)}`)
@@ -218,7 +219,6 @@ class BotiumConnectorAlexaSmapi {
           if (callResponse.status !== 'SUCCESSFUL') {
             return reject(new Error(`Skill invocation returned status ${callResponse.status}`))
           } else if (callResponse.result && callResponse.result.error) {
-            console.log(JSON.stringify(callResponse, null, 4))
             return reject(new Error(`Skill invocation failed with message: ${callResponse.result.error || callResponse.result}`))
           }
           resolve()
@@ -274,13 +274,18 @@ class BotiumConnectorAlexaSmapi {
   }
 
   _handleAudioPlayerRequest (currentInvocationRequest) {
-    const audioPlayerIntent = currentInvocationRequest.request.type.split('.')[1]
-    currentInvocationRequest.request.token = this.invocationRequest.context.AudioPlayer.token
+    if (currentInvocationRequest.request.type.includes('AudioPlayer')) {
+      const audioPlayerIntent = currentInvocationRequest.request.type.split('.')[1]
+      currentInvocationRequest.request.token = this.invocationRequest.context.AudioPlayer.token
 
-    switch (audioPlayerIntent) {
-      case 'PlaybackFailed':
-        currentInvocationRequest.request.error = { message: 'Botium AudioPlayer.PlaybackFailed error message' }
-        break
+      switch (audioPlayerIntent) {
+        case 'PlaybackFailed':
+          currentInvocationRequest.request.error = { message: 'Botium AudioPlayer.PlaybackFailed error message' }
+          break
+      }
+    } else {
+      delete currentInvocationRequest.request.error
+      delete currentInvocationRequest.request.token
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -204,7 +204,7 @@ class BotiumConnectorAlexaSmapi {
         currentInvocationRequest.request.timestamp = (new Date()).toISOString()
 
         if (currentInvocationRequest.request.type.includes('AudioPlayer')) {
-          currentInvocationRequest.request.token = this.invocationRequest.context.AudioPlayer.token
+          this._handleAudioPlayerRequest(currentInvocationRequest)
         } else {
           delete currentInvocationRequest.request.token
         }
@@ -218,6 +218,7 @@ class BotiumConnectorAlexaSmapi {
           if (callResponse.status !== 'SUCCESSFUL') {
             return reject(new Error(`Skill invocation returned status ${callResponse.status}`))
           } else if (callResponse.result && callResponse.result.error) {
+            console.log(JSON.stringify(callResponse, null, 4))
             return reject(new Error(`Skill invocation failed with message: ${callResponse.result.error || callResponse.result}`))
           }
           resolve()
@@ -270,6 +271,17 @@ class BotiumConnectorAlexaSmapi {
       })
     }
     return Promise.resolve()
+  }
+
+  _handleAudioPlayerRequest (currentInvocationRequest) {
+    const audioPlayerIntent = currentInvocationRequest.request.type.split('.')[1]
+    currentInvocationRequest.request.token = this.invocationRequest.context.AudioPlayer.token
+
+    switch (audioPlayerIntent) {
+      case 'PlaybackFailed':
+        currentInvocationRequest.request.error = { message: 'Botium AudioPlayer.PlaybackFailed error message' }
+        break
+    }
   }
 
   _handleAudioPlayerEvent (event, audioPlayer) {

--- a/index.js
+++ b/index.js
@@ -239,8 +239,13 @@ class BotiumConnectorAlexaSmapi {
         if (audioPlayer.audioItem.stream.token) {
           this.invocationRequest.context.AudioPlayer.token = audioPlayer.audioItem.stream.token
         }
+        if (audioPlayer.audioItem.stream.offsetInMilliseconds) {
+          this.invocationRequest.context.AudioPlayer.offsetInMilliseconds = audioPlayer.audioItem.stream.offsetInMilliseconds
+        }
         break
       case 'STOP':
+        this.invocationRequest.context.AudioPlayer.playerActivity = 'STOPPED'
+        this.invocationRequest.context.AudioPlayer.offsetInMilliseconds = 0
         break
     }
   }

--- a/index.js
+++ b/index.js
@@ -40,12 +40,12 @@ class BotiumConnectorAlexaSmapi {
     this.locale = this.caps['ALEXA_SMAPI_LOCALE'] || 'en-US'
     this.endpointRegion = this.caps['ALEXA_SMAPI_ENDPOINTREGION'] || 'default'
 
-    this.audioCapability = this.caps['ALEXA_SMAPI_AUDIO_CAPABILITY'] === true
-    this.displayCapability = this.caps['ALEXA_SMAPI_DISPLAY_CAPABILITY'] === true
+    this.audioCapability = !!this.caps['ALEXA_SMAPI_AUDIO_CAPABILITY']
+    this.displayCapability = !!this.caps['ALEXA_SMAPI_DISPLAY_CAPABILITY']
 
-    this.refreshUserId = this.caps['ALEXA_SMAPI_REFRESH_USER_ID'] === true
+    this.refreshUserId = !!this.caps['ALEXA_SMAPI_REFRESH_USER_ID']
 
-    this.keepAudioPlayerState = this.caps['ALEXA_SMAPI_KEEP_AUDIO_PLAYER_STATE'] === true
+    this.keepAudioPlayerState = !!this.caps['ALEXA_SMAPI_KEEP_AUDIO_PLAYER_STATE']
 
     if (this.caps['ALEXA_SMAPI_REFRESHTOKEN'] || this.caps['ALEXA_SMAPI_ACCESSTOKEN']) {
       this.profile = askConstants.PLACEHOLDER.ENVIRONMENT_VAR.PROFILE_NAME
@@ -123,7 +123,7 @@ class BotiumConnectorAlexaSmapi {
                   const simulationResult = askTools.convertDataToJsonObject(response.result.skillExecutionInfo.invocationResponse.body.response)
                   debug(`got simulation result: ${JSON.stringify(simulationResult)}`)
 
-                  let messageText = 'no text response from skill'
+                  let messageText
                   if (simulationResult && simulationResult.outputSpeech) {
                     messageText = simulationResult.outputSpeech.text || simulationResult.outputSpeech.ssml
                   }

--- a/index.js
+++ b/index.js
@@ -41,6 +41,8 @@ class BotiumConnectorAlexaSmapi {
     this.audioCapability = this.caps['ALEXA_SMAPI_AUDIO_CAPABILITY'] === true
     this.displayCapability = this.caps['ALEXA_SMAPI_DISPLAY_CAPABILITY'] === true
 
+    this.refreshUserId = this.caps['ALEXA_SMAPI_REFRESH_USER_ID'] === true
+
     if (this.caps['ALEXA_SMAPI_REFRESHTOKEN'] || this.caps['ALEXA_SMAPI_ACCESSTOKEN']) {
       this.profile = askConstants.PLACEHOLDER.ENVIRONMENT_VAR.PROFILE_NAME
 
@@ -266,8 +268,11 @@ class BotiumConnectorAlexaSmapi {
     this.invocationRequest.session.application.applicationId = this.skillId
     this.invocationRequest.context.System.application.applicationId = this.skillId
     this.invocationRequest.request.locale = this.locale
-    this._createNewUserId()
     this._addSupportedInterfaces()
+
+    if (this.refreshUserId) {
+      this._createNewUserId()
+    }
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -123,17 +123,14 @@ class BotiumConnectorAlexaSmapi {
                   const simulationResult = askTools.convertDataToJsonObject(response.result.skillExecutionInfo.invocationResponse.body.response)
                   debug(`got simulation result: ${JSON.stringify(simulationResult)}`)
 
-                  const responseBody = simulationResult
-
                   let messageText = 'no text response from skill'
-                  if (responseBody && responseBody.outputSpeech) {
-                    messageText = responseBody.outputSpeech.text || responseBody.outputSpeech.ssml
+                  if (simulationResult && simulationResult.outputSpeech) {
+                    messageText = simulationResult.outputSpeech.text || simulationResult.outputSpeech.ssml
                   }
 
                   let media
-
-                  if (responseBody && responseBody.directives) {
-                    responseBody.directives.forEach(directive => {
+                  if (simulationResult && simulationResult.directives) {
+                    simulationResult.directives.forEach(directive => {
                       if (directive.type.includes('AudioPlayer')) {
                         const audioPlayerObject = directive
                         media = ((audioPlayerObject && audioPlayerObject.audioItem) ? [{
@@ -242,7 +239,6 @@ class BotiumConnectorAlexaSmapi {
             }
 
             let media
-
             if (responseBody.response.directives) {
               responseBody.response.directives.forEach(directive => {
                 if (directive.type.includes('AudioPlayer')) {
@@ -296,7 +292,7 @@ class BotiumConnectorAlexaSmapi {
   }
 
   _createNewUserId () {
-    const userId = `botium-test-user-${uuidv1()}`
+    const userId = `botium-core-test-user-${uuidv1()}`
     this.invocationRequest.session.user.userId = userId
     this.invocationRequest.context.System.user.userId = userId
   }

--- a/index.js
+++ b/index.js
@@ -13,6 +13,16 @@ class BotiumConnectorAlexaSmapi {
     this.caps = caps
   }
 
+  Stop () {
+    debug('Stop called')
+    return Promise.resolve()
+  }
+
+  Clean () {
+    debug('Clean called')
+    return Promise.resolve()
+  }
+
   Validate () {
     debug('Validate called')
     if (this.caps['ALEXA_SMAPI_API'] && this.caps['ALEXA_SMAPI_API'] !== 'simulation' && this.caps['ALEXA_SMAPI_API'] !== 'invocation') throw new Error('ALEXA_SMAPI_API capability invalid (allowed values: "simulation", "invoication"')
@@ -27,6 +37,9 @@ class BotiumConnectorAlexaSmapi {
     this.skillId = this.caps['ALEXA_SMAPI_SKILLID']
     this.locale = this.caps['ALEXA_SMAPI_LOCALE'] || 'en-US'
     this.endpointRegion = this.caps['ALEXA_SMAPI_ENDPOINTREGION'] || 'default'
+
+    this.audioCapability = this.caps['ALEXA_SMAPI_AUDIO_CAPABILITY'] === true
+    this.displayCapability = this.caps['ALEXA_SMAPI_DISPLAY_CAPABILITY'] === true
 
     if (this.caps['ALEXA_SMAPI_REFRESHTOKEN'] || this.caps['ALEXA_SMAPI_ACCESSTOKEN']) {
       this.profile = askConstants.PLACEHOLDER.ENVIRONMENT_VAR.PROFILE_NAME
@@ -119,7 +132,7 @@ class BotiumConnectorAlexaSmapi {
     }
     if (this.api === 'invocation') {
       return new Promise((resolve, reject) => {
-        const currentInvocationRequest = _.clone(this.invocationRequest)
+        let currentInvocationRequest = _.clone(this.invocationRequest)
 
         if (msg.sourceData) {
           _.merge(currentInvocationRequest.request, msg.sourceData)
@@ -130,6 +143,12 @@ class BotiumConnectorAlexaSmapi {
             currentInvocationRequest.request.intent.slots[this.invocationTextSlot] = { name: this.invocationTextSlot, value: msg.messageText }
           } else {
             const [ requestType, intentName ] = msg.messageText.split(' ')
+
+            if (requestType === 'LaunchIntent') {
+              this._buildNewInvokeRequest()
+              currentInvocationRequest = _.clone(this.invocationRequest)
+            }
+
             currentInvocationRequest.request.type = requestType
             if (intentName) {
               currentInvocationRequest.request.intent.name = intentName
@@ -138,6 +157,14 @@ class BotiumConnectorAlexaSmapi {
         }
         currentInvocationRequest.request.requestId = uuidv1()
         currentInvocationRequest.request.timestamp = (new Date()).toISOString()
+
+        if (currentInvocationRequest.request.type.includes('AudioPlayer')) {
+          const audioPlayerRequest = currentInvocationRequest.request.type.split('.')[1]
+          this._handleAudioPlayerRequest(audioPlayerRequest, currentInvocationRequest)
+        } else {
+          delete currentInvocationRequest.request.token
+        }
+
         debug(`currentInvocationRequest: ${JSON.stringify(currentInvocationRequest)}`)
 
         askApi.callInvokeSkill(null, currentInvocationRequest, this.skillId, this.endpointRegion, this.profile, debug.enabled, smapiCallbackTimeout((data) => {
@@ -160,8 +187,31 @@ class BotiumConnectorAlexaSmapi {
                 Object.assign(this.invocationRequest.session.attributes, responseBody.sessionAttributes)
               }
             }
-            const messageText = responseBody.response.outputSpeech.text || responseBody.response.outputSpeech.ssml
-            const botMsg = { sender: 'bot', sourceData: responseBody, messageText }
+
+            let messageText = 'no text response'
+            if (responseBody.response.outputSpeech) {
+              messageText = responseBody.response.outputSpeech.text || responseBody.response.outputSpeech.ssml
+            }
+
+            let audioPlayerObject
+            let audioPlayerType
+            if (responseBody.response.directives) {
+              responseBody.response.directives.forEach(directive => {
+                if (directive.type.includes('AudioPlayer')) {
+                  audioPlayerObject = directive
+                  audioPlayerType = directive.type.split('.')[1].toUpperCase()
+                }
+              })
+            }
+
+            let media
+            if (audioPlayerObject && audioPlayerObject.audioItem) {
+              media = [{ mediaUri: audioPlayerObject.audioItem.stream.url }]
+            }
+
+            this._handleAudioPlayerEvent(audioPlayerType, audioPlayerObject)
+
+            const botMsg = { sender: 'bot', sourceData: responseBody, messageText, media }
             this.queueBotSays(botMsg)
           }
           resolve()
@@ -171,14 +221,51 @@ class BotiumConnectorAlexaSmapi {
     return Promise.resolve()
   }
 
-  Stop () {
-    debug('Stop called')
-    return Promise.resolve()
+  _handleAudioPlayerRequest (request, currentInvocationRequest) {
+    switch (request) {
+      case 'PlaybackNearlyFinished':
+        currentInvocationRequest.request.token = this.invocationRequest.context.AudioPlayer.token
+        break
+      default:
+        delete this.invocationRequest.request.token
+        break
+    }
   }
 
-  Clean () {
-    debug('Clean called')
-    return Promise.resolve()
+  _handleAudioPlayerEvent (event, audioPlayer) {
+    switch (event) {
+      case 'PLAY':
+        this.invocationRequest.context.AudioPlayer.playerActivity = 'PLAYING'
+        if (audioPlayer.audioItem.stream.token) {
+          this.invocationRequest.context.AudioPlayer.token = audioPlayer.audioItem.stream.token
+        }
+        break
+      case 'STOP':
+        break
+    }
+  }
+
+  _createNewUserId () {
+    const userId = `botium-test-user-${uuidv1()}`
+    this.invocationRequest.session.user.userId = userId
+    this.invocationRequest.context.System.user.userId = userId
+  }
+
+  _addSupportedInterfaces () {
+    if (this.displayCapability || this.audioCapability) {
+      const supportedInterfaces = {
+        AudioPlayer: (this.audioCapability ? {} : undefined),
+        Display: (!this.displayCapability ? undefined : {
+          templateVersion: '1.0',
+          markupVersion: '1.0'
+        })
+      }
+
+      this.invocationRequest.context.System.device = {
+        deviceId: uuidv1(),
+        supportedInterfaces
+      }
+    }
   }
 
   _buildNewInvokeRequest () {
@@ -188,6 +275,8 @@ class BotiumConnectorAlexaSmapi {
     this.invocationRequest.session.application.applicationId = this.skillId
     this.invocationRequest.context.System.application.applicationId = this.skillId
     this.invocationRequest.request.locale = this.locale
+    this._createNewUserId()
+    this._addSupportedInterfaces()
   }
 }
 


### PR DESCRIPTION
References: https://github.com/codeforequity-at/botium-core/issues/312

This PR contains changes mainly to the Invocation section of the connector. 

The reason for this  is because I wanted to add the ability to send AudioPlayer intents which can't really be specified in simulation, such as `AudioPlayer.PlaybackNearlyFinished` and other AudioPlayer intents. 

### New Assertions
When receiving a media response with an AudioPlayer directive we can now check that the media uri is correct using the media tag
``` MEDIA www.example.com/test.mp3```

### New Capabilities
#### ALEXA_SMAPI_AUDIO_CAPABILITY and ALEXA_SMAPI_DISPLAY_CAPABILITY
These when set to `true` will add audio / display capabilities to the requestTemplate. This can be done on both simulation and invocation

#### ALEXA_SMAPI_REFRESH_USER_ID
When set to true a new userId will be generated every conv.txt file for cases when you want to test databases on the skill that involve a userId such as playing audio files a max of 3 times for regular users. This only works with invocation since it updates the invocationRequest object

#### ALEXA_SMAPI_KEEP_AUDIO_PLAYER_STATE
This is the big change in this PR and will allow changes on the audioPlayer when botium receives an AudioPlayer response / directive. it will adapt the invocation template with the audioPlayers event. 
So it can set the `token`, `offsetInMilliseconds` and the `playerActivity` The only audio player events this supports at the moment is 'PLAY' and 'STOP'
This only works with invocation since it updates the invocationRequest object


